### PR TITLE
Trivial typo fix for virtualenv creation in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,7 @@ function setup_env () {
         exit 0
     else
         git submodule update --init --recursive && build_env $1
-        vitualenv . --prompt="[$1] "
+        virtualenv . --prompt="[$1] "
     fi
 }
 


### PR DESCRIPTION
Forgive my Github weakness. It appears that I have turned a trivial typo patch into two commits because of the use of a local branch and merge for the change in my clone of your repo.